### PR TITLE
Provide lists of public and private subnet IDs as an output

### DIFF
--- a/lib/sparkleformation/nat_subnet_vpc.rb
+++ b/lib/sparkleformation/nat_subnet_vpc.rb
@@ -5,6 +5,9 @@ SparkleFormation.new(:lazy_vpc__nat_subnet_vpc, :inherit => :public_subnet_vpc).
   ## Access the list of available Availability Zones via registry entry.
   zones = registry!(:zones)
 
+  ## Instantiate an empty array to collect our private subnet IDs
+  private_subnet_ids = []
+
   nat_zone = zones.first.gsub('-','_')
   ## Iterate over each AZ creating a public subnet. Auto-generate
   ## Subnet CIDRs based on index.
@@ -25,9 +28,16 @@ SparkleFormation.new(:lazy_vpc__nat_subnet_vpc, :inherit => :public_subnet_vpc).
     outputs("#{['private_', zone.gsub('-', '_') ].join}_subnet".to_sym) do
       value ref!("#{['private_', zone.gsub('-', '_') ].join}_subnet".to_sym)
     end
+
+    private_subnet_ids.push(ref!(['private_', zone.gsub('-', '_'), '_subnet'].join.to_sym))
+  end
+
+  outputs(:private_subnet_ids) do
+    value private_subnet_ids
   end
 
   dynamic!(:vpc_nat_routing, :nat_vpc,
     :nat_subnet => ref!("public_#{nat_zone}_subnet".to_sym),
-    :nat_route_table => ref!(:private_route_table))
+    :nat_route_table => ref!(:private_route_table)
+  )
 end

--- a/lib/sparkleformation/nat_subnet_vpc.rb
+++ b/lib/sparkleformation/nat_subnet_vpc.rb
@@ -33,7 +33,7 @@ SparkleFormation.new(:lazy_vpc__nat_subnet_vpc, :inherit => :public_subnet_vpc).
   end
 
   outputs(:private_subnet_ids) do
-    value private_subnet_ids
+    value join!(private_subnet_ids, :options => { :delimiter => ',' })
   end
 
   dynamic!(:vpc_nat_routing, :nat_vpc,

--- a/lib/sparkleformation/public_subnet_vpc.rb
+++ b/lib/sparkleformation/public_subnet_vpc.rb
@@ -26,7 +26,7 @@ SparkleFormation.new(:lazy_vpc__public_subnet_vpc).load(:base, :vpc).overrides d
   end
 
   outputs(:public_subnet_ids) do
-    value public_subnet_ids
+    value join!(public_subnet_ids, :options => { :delimiter => ',' })
   end
 
 end

--- a/lib/sparkleformation/public_subnet_vpc.rb
+++ b/lib/sparkleformation/public_subnet_vpc.rb
@@ -5,9 +5,12 @@ SparkleFormation.new(:lazy_vpc__public_subnet_vpc).load(:base, :vpc).overrides d
   ## Access the list of available Availability Zones via registry entry.
   zones = registry!(:zones)
 
+  ## Instantiate an empty array to collect our public subnet IDs
+  public_subnet_ids = []
+
   ## Iterate over each AZ creating a public subnet. Auto-generate
   ## Subnet CIDRs based on index.
-    zones.each_with_index do |zone, index|
+  zones.each_with_index do |zone, index|
 
     dynamic!(:vpc_subnet, ['public_', zone.gsub('-', '_') ].join,
       :vpc_id => ref!(:vpc),
@@ -19,6 +22,11 @@ SparkleFormation.new(:lazy_vpc__public_subnet_vpc).load(:base, :vpc).overrides d
       default ['10.0.', index, '.0/24'].join
     end
 
+    public_subnet_ids.push(ref!(['public_', zone.gsub('-', '_'), '_subnet'].join.to_sym))
+  end
+
+  outputs(:public_subnet_ids) do
+    value public_subnet_ids
   end
 
 end


### PR DESCRIPTION
I sometimes find it convenient to remain agnostic about the actual names of the AZs I am provisioning into, and I find that providing a list of subnet ids as a single output makes that easier. This PR adds `public_subnet_ids` and `private_subnet_ids` outputs to the Public and NAT VPC templates, respectively.
